### PR TITLE
Hot fix to add 'X-ray computed tomography' to imaging_type

### DIFF
--- a/records/new_images/common_fields_spec.yaml
+++ b/records/new_images/common_fields_spec.yaml
@@ -2,10 +2,11 @@ Imaging_type:
   compulsory: True
   yaml: True
   description: >
-    The label of an imaging type from FBbi. imaging_type: One of: 'confocal microscopy', TEM, 'SB-SEM', 'computer graphic'.
+    The label of an imaging type from FBbi. imaging_type: One of: 'confocal microscopy', TEM, 'SB-SEM', 'computer graphic', 'X-ray computed tomography'.
        - SB-SEM = serial block face scanning EM (use for FIB-SEM data)
        - TEM = transmission electron microscopy (TEM) (use for CATMAID data)
        - 'computer graphic' is used for painted domains.
+       - 'X-ray computed tomography' is also used for X-ray holographic nano-tomography
     If your image does not fit into these types, please post a ticket to request the list of supported types be extended.
   pattern_arg: imaging_type
 


### PR DESCRIPTION
matching           'X-ray computed tomography': 'http://purl.obolibrary.org/obo/FBbi_00001002'