### PR TITLE
Fix for FutureWarning

### DIFF
--- a/src/vfb/curation/peevish.py
+++ b/src/vfb/curation/peevish.py
@@ -150,6 +150,8 @@ class Record:
         for cr in cur_recs:
             if cr.ext == 'tsv':
                 self.tsv = pd.read_csv(cr.path, sep="\t")
+                # Convert the DataFrame to 'object' type before filling NaN values
+                self.tsv = self.tsv.astype(object)
                 self.tsv.fillna('', inplace=True)
                 self.cr = cr
                 self.type = self.cr.type


### PR DESCRIPTION
/var/jenkins_home/workspace/Test_Robbie1977_curation/curation/src/vfb/curation/peevish.py:153: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
  self.tsv.fillna('', inplace=True)